### PR TITLE
Update #1 icecc and build-essential

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,15 @@ FROM crops/poky:debian-12
 USER root
 
 RUN apt update && apt install -y \
-    python3-venv && apt autoremove && \
+    python3-venv icecc build-essential && apt autoremove && \
     rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --upgrade pip && \
     /opt/venv/bin/pip install kas
+
+EXPOSE 10245/tcp
+EXPOSE 8766/tcp
 
 USER usersetup
 


### PR DESCRIPTION
This commit updates the docker file with icecc (icecream compiler) and build-essential. Also expose port 10245 & 8766 for icecc.